### PR TITLE
xcb-util-cursor 0.1.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - rafaelmartins-qt
-
-upload_without_merge: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,4 +4,4 @@ set -ex
 ./configure --prefix="${PREFIX}"
 make -j ${CPU_COUNT}
 make check
-make install 
+make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,9 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/lib/libxcb-cursor.so
-  downstreams:
-    - qtbase
+  # Check downstream packages if needed.
+  # downstreams:
+  #   - qtbase
 
 about:
   description: xcb-util port of libxcursor.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xcb-util-cursor" %}
-{% set version = "0.1.4" %}
+{% set version = "0.1.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://xcb.freedesktop.org/dist/xcb-util-cursor-{{ version }}.tar.xz
-  sha256: 28dcfe90bcab7b3561abe0dd58eb6832aa9cc77cfe42fcdfa4ebe20d605231fb
+  sha256: 0caf99b0d60970f81ce41c7ba694e5eaaf833227bb2cbcdb2f6dc9666a663c57
 
 build:
   number: 0
-  skip: true  # [s390x or not linux]
+  skip: true  # [not linux]
   run_exports:
     - {{ pin_subpackage('xcb-util-cursor', max_pin='x.x') }}
 
@@ -21,15 +21,13 @@ requirements:
     - make
     - m4
     - pkg-config
-    - {{ cdt('libxau-devel') }}               # [linux]
-    - {{ cdt('xorg-x11-proto-devel') }}       # [linux]
-    - {{ cdt('xcb-util-devel') }}             # [linux]
-    - {{ cdt('xcb-util-image-devel') }}       # [linux]
-    - {{ cdt('xcb-util-renderutil-devel') }}  # [linux]
   host:
-    - libxcb 1.15
+    - libxcb >=1.13
+    - xorg-xproto
+    - xcb-util-renderutil
+    - xcb-util-image
   run:
-    - libxcb >=1.15
+    - libxcb >=1.13
 
 test:
   commands:
@@ -43,4 +41,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: COPYING
-  summary: 'port of Xlib libXcursor functions'
+  summary: port of Xlib libXcursor functions
+
+extra:
+  recipe-maintainers:
+    - n-elie

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/lib/libxcb-cursor.so
+  downstreams:
+    - qtbase
 
 about:
   description: xcb-util port of libxcursor.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pkg-config
   host:
     - libxcb >=1.13
-    - xorg-xproto
+    - xorg-xorgproto
     - xcb-util-renderutil
     - xcb-util-image
   run:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8095](https://anaconda.atlassian.net/browse/PKG-8095) 
- [Upstream repository](https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor)

### Explanation of changes:

- Use xorg/xcb conda packages instead of CDTs. Based on the conda-forge recipe

### Notes:

-

[PKG-8095]: https://anaconda.atlassian.net/browse/PKG-8095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ